### PR TITLE
06-cmake-warnings-cxx-std

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.19)
 project(TelltaleEditor VERSION 0.0.1)
 
 set(CMAKE_BUILD_TYPE Debug) # Set the build type to debug by default
-set(CMAKE_CXX_STANDARD 17) # Use C++17
+set(CMAKE_CXX_STANDARD 14) # Use C++14
 set(BUILD_SHARED_LIBS OFF) # Build static libraries
 set(CMAKE_CXX_FLAGS_DEBUG "-g") # debug info compiler flag
 set(CMAKE_CXX_FLAGS_RELEASE "-O3") # optimization compiler flag

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.19)
 project(TelltaleEditor VERSION 0.0.1)
 
 set(CMAKE_BUILD_TYPE Debug) # Set the build type to debug by default
-set(CMAKE_CXX_STANDARD 14) # Use C++14
+set(CMAKE_CXX_STANDARD 17) # Use C++17
 set(BUILD_SHARED_LIBS OFF) # Build static libraries
 set(CMAKE_CXX_FLAGS_DEBUG "-g") # debug info compiler flag
 set(CMAKE_CXX_FLAGS_RELEASE "-O3") # optimization compiler flag

--- a/TelltaleEditor/3rdparty/lua52/CMakeLists.txt
+++ b/TelltaleEditor/3rdparty/lua52/CMakeLists.txt
@@ -37,3 +37,4 @@ ${lua_SOURCE_DIR}/lzio.c
 )
 
 target_include_directories(lua PUBLIC ${lua_SOURCE_DIR}) 
+ignore_warnings(lua)

--- a/TelltaleEditor/3rdparty/lua52/CMakeLists.txt
+++ b/TelltaleEditor/3rdparty/lua52/CMakeLists.txt
@@ -37,4 +37,4 @@ ${lua_SOURCE_DIR}/lzio.c
 )
 
 target_include_directories(lua PUBLIC ${lua_SOURCE_DIR}) 
-ignore_warnings(lua)
+ignore_warnings(lua 0)

--- a/TelltaleEditor/3rdparty/zlib/CMakeLists.txt
+++ b/TelltaleEditor/3rdparty/zlib/CMakeLists.txt
@@ -14,4 +14,4 @@ ${zlib_SOURCE_DIR}/trees.c
 )
 
 target_include_directories(zlib PUBLIC ${zlib_SOURCE_DIR}) 
-ignore_warnings(zlib)
+ignore_warnings(zlib 0)

--- a/TelltaleEditor/3rdparty/zlib/CMakeLists.txt
+++ b/TelltaleEditor/3rdparty/zlib/CMakeLists.txt
@@ -14,3 +14,4 @@ ${zlib_SOURCE_DIR}/trees.c
 )
 
 target_include_directories(zlib PUBLIC ${zlib_SOURCE_DIR}) 
+ignore_warnings(zlib)

--- a/TelltaleEditor/3rdparty/zlib/inflate.c
+++ b/TelltaleEditor/3rdparty/zlib/inflate.c
@@ -1504,7 +1504,7 @@ z_streamp strm;
 {
     struct inflate_state FAR *state;
 
-    if (strm == Z_NULL || strm->state == Z_NULL) return -1L << 16;
+    if (strm == Z_NULL || strm->state == Z_NULL) return -(1L << 16);
     state = (struct inflate_state FAR *)strm->state;
     return ((long)(state->back) << 16) +
         (state->mode == COPY ? state->length :

--- a/TelltaleEditor/CMakeLists.txt
+++ b/TelltaleEditor/CMakeLists.txt
@@ -40,7 +40,7 @@ function(set_platform_type target) # Enable platform specific defines
 endfunction()
 
 function (ignore_warnings target) # ignore specific warnings, but disallow vla
-	target_compile_options(${target} PRIVATE "-Wno-reorder;-Wno-format-extra-args;-Wno-deprecated;-Wvla-extension")
+	target_compile_options(${target} PRIVATE "-Wno-reorder;-Wno-format-extra-args;-Wno-deprecated;-Werror=vla")
 endfunction()
 
 add_subdirectory(3rdparty) # Add the dependencies/libraries

--- a/TelltaleEditor/CMakeLists.txt
+++ b/TelltaleEditor/CMakeLists.txt
@@ -39,6 +39,10 @@ function(set_platform_type target) # Enable platform specific defines
     endif()
 endfunction()
 
+function (ignore_warnings target) # ignore specific warnings, but disallow vla
+	target_compile_options(${target} PRIVATE "-Wno-reorder;-Wno-format-extra-args;-Wno-deprecated;-Wvla-extension")
+endfunction()
+
 add_subdirectory(3rdparty) # Add the dependencies/libraries
 add_subdirectory(Source/ToolLibrary) # Add the Source Directory for both the library and UI
 add_subdirectory(Source/Editor) # Add the Source Directory for both the library and UI

--- a/TelltaleEditor/CMakeLists.txt
+++ b/TelltaleEditor/CMakeLists.txt
@@ -39,8 +39,24 @@ function(set_platform_type target) # Enable platform specific defines
     endif()
 endfunction()
 
-function (ignore_warnings target) # ignore specific warnings, but disallow vla
-	target_compile_options(${target} PRIVATE "-Wno-reorder;-Wno-format-extra-args;-Wno-deprecated;-Werror=vla")
+function (ignore_warnings target is_cpp) # ignore specific warnings, but disallow vla
+	set(FINAL_WARNINGS "")
+
+	if(is_cpp EQUAL 1) # cpp specific all platform warnings
+		set(FINAL_WARNINGS "${FINAL_WARNINGS}-Wno-reorder;")
+	endif()
+
+	if(UNIX)
+		if(APPLE)
+			set(FINAL_WARNINGS "${FINAL_WARNINGS}-Wno-format-extra-args;-Wno-deprecated;-Werror=vla;")
+		else()
+            		set(FINAL_WARNINGS "${FINAL_WARNINGS}-Wno-format-extra-args;-Wno-deprecated;-Werror=vla;")
+		endif()
+	elseif(WIN32)
+		set(FINAL_WARNINGS "${FINAL_WARNINGS}") # any msvc specific stuff in the future
+	endif()
+
+	target_compile_options(${target} PRIVATE ${FINAL_WARNINGS})
 endfunction()
 
 add_subdirectory(3rdparty) # Add the dependencies/libraries

--- a/TelltaleEditor/CMakeLists.txt
+++ b/TelltaleEditor/CMakeLists.txt
@@ -43,7 +43,9 @@ function (ignore_warnings target is_cpp) # ignore specific warnings, but disallo
 	set(FINAL_WARNINGS "")
 
 	if(is_cpp EQUAL 1) # cpp specific all platform warnings
-		set(FINAL_WARNINGS "${FINAL_WARNINGS}-Wno-reorder;")
+		if(UNIX)
+			set(FINAL_WARNINGS "${FINAL_WARNINGS}-Wno-reorder;")
+		endif()
 	endif()
 
 	if(UNIX)

--- a/TelltaleEditor/Source/Editor/CMakeLists.txt
+++ b/TelltaleEditor/Source/Editor/CMakeLists.txt
@@ -10,12 +10,11 @@ target_link_libraries(${TARGET_NAME} PUBLIC lua)
 target_link_libraries(${TARGET_NAME} PUBLIC zlib)
 target_link_libraries(${TARGET_NAME} PUBLIC ToolLibrary)
 
-set_target_properties(${TARGET_NAME} PROPERTIES CXX_STANDARD 17 OUTPUT_NAME "TelltaleEditor")
+set_target_properties(${TARGET_NAME} PROPERTIES CXX_STANDARD 14 OUTPUT_NAME "TelltaleEditor")
 set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "TelltaleEditor")
-
-target_compile_options(Editor PRIVATE -Wall) # Show all warnings and prohibit variable-length arrays
-target_compile_options(ToolLibrary PRIVATE -Wall)
 
 # Enable platform specific defines
 set_build_type(${TARGET_NAME})
 set_platform_type(${TARGET_NAME})
+
+ignore_warnings(${TARGET_NAME})

--- a/TelltaleEditor/Source/Editor/CMakeLists.txt
+++ b/TelltaleEditor/Source/Editor/CMakeLists.txt
@@ -17,4 +17,4 @@ set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "TelltaleEditor")
 set_build_type(${TARGET_NAME})
 set_platform_type(${TARGET_NAME})
 
-ignore_warnings(${TARGET_NAME})
+ignore_warnings(${TARGET_NAME} 1)

--- a/TelltaleEditor/Source/ToolLibrary/CMakeLists.txt
+++ b/TelltaleEditor/Source/ToolLibrary/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(ToolLibrary STATIC
 set_build_type(${TARGET_NAME})
 set_platform_type(${TARGET_NAME})
 
+ignore_warnings(${TARGET_NAME})
+
 set_target_properties(ToolLibrary PROPERTIES FOLDER "TelltaleEditor")
 
 target_include_directories(ToolLibrary PUBLIC ${TELLTALE_LIB_HEADERS_DIR} ${CMAKE_CURRENT_SOURCE_DIR})

--- a/TelltaleEditor/Source/ToolLibrary/CMakeLists.txt
+++ b/TelltaleEditor/Source/ToolLibrary/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(ToolLibrary STATIC
 set_build_type(${TARGET_NAME})
 set_platform_type(${TARGET_NAME})
 
-ignore_warnings(${TARGET_NAME})
+ignore_warnings(${TARGET_NAME} 1)
 
 set_target_properties(ToolLibrary PROPERTIES FOLDER "TelltaleEditor")
 

--- a/TelltaleEditor/Source/ToolLibrary/Include/Scheduler/JobScheduler.hpp
+++ b/TelltaleEditor/Source/ToolLibrary/Include/Scheduler/JobScheduler.hpp
@@ -79,7 +79,7 @@ struct Job {
 	U32 JobID;
 
 	// Default Constructor
-	inline Job() : RunnableFunction(0), UserArgA(0), UserArgB(0), JobID(0), Priority(JobPriority::JOB_PRIORITY_NORMAL) {}
+	inline Job() : RunnableFunction(0), UserArgA(0), UserArgB(0), Priority(JobPriority::JOB_PRIORITY_NORMAL), JobID(0) {}
 
 	// Comparison operator for the priority queue.
 	inline bool operator<(const Job& rhs) const {
@@ -208,10 +208,10 @@ struct JobList {
 	U32 NumQueued; // Number of queued jobs
 
 	// Initialises to size of 1.
-	inline JobList(Job&& queued) : NumQueued(1), Singular(std::move(queued)) {}
+	inline JobList(Job&& queued) : Singular(std::move(queued)), NumQueued(1) {}
 
 	// Initialises to size of 0.
-	inline JobList() : NumQueued(0), Singular() {}
+	inline JobList() : Singular(), NumQueued(0) {}
 
 	//Appends a job to the list.
 	void Append(Job&& job);

--- a/TelltaleEditor/Source/ToolLibrary/Source/Scheduler/JobScheduler.cpp
+++ b/TelltaleEditor/Source/ToolLibrary/Source/Scheduler/JobScheduler.cpp
@@ -393,7 +393,7 @@ void JobScheduler::_RegisterJobs(U32 nJobs, JobDescriptor* pJobDescriptors, JobH
 
 }
 
-JobScheduler::JobScheduler() : _jobThreadNotifierCount(0), _cancelJobs(false), _running(true), _runningID(0)
+JobScheduler::JobScheduler() : _jobThreadNotifierCount(0),  _running(true), _cancelJobs(false), _runningID(0)
 {
 	// Job thread notifier counter is 0 to begin with, ie threads will wait until jobs come.
 


### PR DESCRIPTION
cmake: disable stupid warnings, vla disallowed, ignore_warnings function defined in cmake. fix some class initialisation order, no warnings on build, fixed zlib sign error from documented on github